### PR TITLE
Allowing loading of access token from ENV file

### DIFF
--- a/lib/messagebird/client.rb
+++ b/lib/messagebird/client.rb
@@ -20,8 +20,8 @@ module MessageBird
   class Client
     attr_reader :access_key
 
-    def initialize(access_key)
-      @access_key = access_key
+    def initialize(access_key = nil)
+      @access_key = access_key || ENV['MESSAGE_BIRD_ACCES_KEY']
     end
 
     def request(method, path, params={})

--- a/lib/messagebird/client.rb
+++ b/lib/messagebird/client.rb
@@ -21,7 +21,7 @@ module MessageBird
     attr_reader :access_key
 
     def initialize(access_key = nil)
-      @access_key = access_key || ENV['MESSAGE_BIRD_ACCESS_KEY']
+      @access_key = access_key || ENV['MESSAGEBIRD_ACCESS_KEY']
     end
 
     def request(method, path, params={})

--- a/lib/messagebird/client.rb
+++ b/lib/messagebird/client.rb
@@ -21,7 +21,7 @@ module MessageBird
     attr_reader :access_key
 
     def initialize(access_key = nil)
-      @access_key = access_key || ENV['MESSAGE_BIRD_ACCES_KEY']
+      @access_key = access_key || ENV['MESSAGE_BIRD_ACCESS_KEY']
     end
 
     def request(method, path, params={})


### PR DESCRIPTION
Allowing the access_token to be loaded directly from an env file, rather than always having to pass it in each time. 