### PR TITLE
make MessageBird::ErrorException a StandardException

### DIFF
--- a/lib/messagebird/client.rb
+++ b/lib/messagebird/client.rb
@@ -10,7 +10,7 @@ require 'messagebird/message'
 require 'messagebird/voicemessage'
 
 module MessageBird
-  class ErrorException < Exception
+  class ErrorException < StandardError
     attr_reader :errors
 
     def initialize(errors)


### PR DESCRIPTION
Non StandardExceptions are reserved for the really really bad stuff like syntax errors and memory issues. 