### PR TITLE
Raise a valid error

### DIFF
--- a/lib/messagebird/client.rb
+++ b/lib/messagebird/client.rb
@@ -51,7 +51,7 @@ module MessageBird
       when 200, 201, 204, 401, 404, 405, 422
         json = JSON.parse(response.body)
       else
-        raise Net::HTTPServerError.new 'Unknown response from server', response
+        raise Net::HTTPServerError.new response.http_version, 'Unknown response from server', response
       end
 
       # If the request returned errors, create Error objects and raise.


### PR DESCRIPTION
Since at least ruby 2.0.0 Net::HTTPServerError requires
3 arguments https://github.com/ruby/ruby/blob/v2_0_0_0/lib/net/http/response.rb#L75
The first one being `http_version` which response has
https://github.com/ruby/ruby/blob/ruby_2_0_0/lib/net/http/response.rb#L87