### PR TITLE
use Exception class when MessageBird replies with an unexpected status code

### DIFF
--- a/lib/messagebird/client.rb
+++ b/lib/messagebird/client.rb
@@ -51,7 +51,7 @@ module MessageBird
       when 200, 201, 204, 401, 404, 405, 422
         json = JSON.parse(response.body)
       else
-        raise Net::HTTPServerError.new response.http_version, 'Unknown response from server', response
+        raise Net::HTTPServerException.new 'Unknown response from server', response
       end
 
       # If the request returned errors, create Error objects and raise.
@@ -141,7 +141,7 @@ module MessageBird
 
     def lookup(phoneNumber, params={})
       Lookup.new(request(:get, "lookup/#{phoneNumber}", params))
-    end 
+    end
 
     def lookup_hlr_create(phoneNumber, params={})
       HLR.new(request(:post, "lookup/#{phoneNumber}/hlr", params))


### PR DESCRIPTION
Currently, if the API responds with a status code other than `200, 201, 204, 401, 404, 405, 422`, the gem tries to raise an error.
However, `HTTPServerError` is *not* an exception class, which in turns causes the following exception:
```
TypeError: exception class/object expected
```

I believe we should use `HttpServerException` instead: https://github.com/ruby/ruby/blob/v2_0_0_0/lib/net/http/exceptions.rb.

WDYT?