### PR TITLE
Raise InvalidPhoneNumberException instead of TypeError

### DIFF
--- a/lib/messagebird/client.rb
+++ b/lib/messagebird/client.rb
@@ -19,6 +19,8 @@ module MessageBird
     end
   end
 
+  class InvalidPhoneNumberException < TypeError; end
+
   class Client
     attr_reader :access_key
 
@@ -51,7 +53,7 @@ module MessageBird
       when 200, 201, 204, 401, 404, 405, 422
         json = JSON.parse(response.body)
       else
-        raise Net::HTTPServerError.new response.http_version, 'Unknown response from server', response
+        raise InvalidPhoneNumberException, 'Unknown response from server'
       end
 
       # If the request returned errors, create Error objects and raise.
@@ -141,7 +143,7 @@ module MessageBird
 
     def lookup(phoneNumber, params={})
       Lookup.new(request(:get, "lookup/#{phoneNumber}", params))
-    end 
+    end
 
     def lookup_hlr_create(phoneNumber, params={})
       HLR.new(request(:post, "lookup/#{phoneNumber}/hlr", params))


### PR DESCRIPTION
Hi!

This PR is the implementation of the fixed proposed in #9.
It provides an actual exception class for lookups of invalid phone numbers.

It's still kind of an abuse of the `TypeError` ancestor, but I believe it's much closer to the intended behaviour that what is currently live in the gem.


PS: Back in #9, you mentioned plans for a major update of the ruby client. Is that still in the plans?