### PR TITLE
Added 1.9.3 to list of Travis allowed failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,7 @@ rvm:
 - jruby
 matrix:
   allow_failures:
-  - rvm:
-    - jruby
-    - 1.9.3
+  - rvm: jruby
+  - rvm: 1.9.3
 install: gem install rspec
 script: rake spec

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ rvm:
 - jruby
 matrix:
   allow_failures:
-  - rvm: jruby
+  - rvm:
+    - jruby
+    - 1.9.3
 install: gem install rspec
 script: rake spec


### PR DESCRIPTION
This PR effectively ends support for Ruby 1.x by adding it to the Travis CI allowed failures.