### PR TITLE
Fix issue #17: raise ServerException instead of InvalidPhoneNumberException

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.gem
+Gemfile.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,5 +8,5 @@ matrix:
   allow_failures:
   - rvm: jruby
   - rvm: 1.9.3
-install: gem install rspec
+install: bundle install
 script: rake spec

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,15 @@
+source 'https://rubygems.org'
+git_source(:github) { |repo| "https://github.com/#{repo}.git" }
+
+# Declare your gem's dependencies in geolocation_service.gemspec.
+# Bundler will treat runtime dependencies like base dependencies, and
+# development dependencies will be added by default to the :development group.
+gemspec
+
+# Declare any dependencies that are still in development here instead of in
+# your gemspec. These might include edge Rails or gems from your path or
+# Git. Remember to move these dependencies to your gemspec before releasing
+# your gem to rubygems.org.
+
+# To use a debugger
+# gem 'byebug', group: [:development, :test]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,23 @@
+PATH
+  remote: .
+  specs:
+    messagebird-rest (2.0.0.pre.rc)
+
 GEM
   remote: https://rubygems.org/
   specs:
+    addressable (2.7.0)
+      public_suffix (>= 2.0.2, < 5.0)
     ast (2.4.0)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
     diff-lcs (1.3)
+    hashdiff (1.0.0)
     jaro_winkler (1.5.4)
     parallel (1.19.1)
     parser (2.6.5.0)
       ast (~> 2.4.0)
+    public_suffix (4.0.3)
     rainbow (3.0.0)
     rspec (3.9.0)
       rspec-core (~> 3.9.0)
@@ -29,14 +40,21 @@ GEM
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 1.7)
     ruby-progressbar (1.10.1)
+    safe_yaml (1.0.5)
     unicode-display_width (1.6.0)
+    webmock (3.7.6)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  messagebird-rest!
   rspec
   rubocop (~> 0.77.0)
+  webmock (~> 3.7.5)
 
 BUNDLED WITH
    1.17.2

--- a/lib/messagebird/http_client.rb
+++ b/lib/messagebird/http_client.rb
@@ -4,7 +4,6 @@ require 'net/https'
 require 'uri'
 
 module MessageBird
-
   class ServerException < StandardError; end
   class InvalidResponseException < StandardError; end
   class MethodNotAllowedException < ArgumentError; end

--- a/lib/messagebird/http_client.rb
+++ b/lib/messagebird/http_client.rb
@@ -3,7 +3,7 @@ require 'uri'
 
 module MessageBird
 
-  class InvalidPhoneNumberException < TypeError; end
+  class ServerException < StandardError; end
   class InvalidResponseException < StandardError; end
   class MethodNotAllowedException < ArgumentError; end
 

--- a/lib/messagebird/http_client.rb
+++ b/lib/messagebird/http_client.rb
@@ -10,7 +10,7 @@ module MessageBird
   class HttpClient
     attr_reader :access_key
 
-    ENDPOINT = 'https://rest.messagebird.com/'
+    ENDPOINT = 'https://rest.messagebird.com/'.freeze
     VALID_RESPONSE_CODES = [200, 201, 202, 204, 401, 404, 405, 422].freeze
 
     def initialize(access_key)

--- a/lib/messagebird/http_client.rb
+++ b/lib/messagebird/http_client.rb
@@ -76,9 +76,6 @@ module MessageBird
     # Throw an exception if the response code is not one we expect from the
     # MessageBird API.
     def assert_valid_response_code(code)
-      # InvalidPhoneNumberException does not make a lot of sense here, but it's
-      # needed to maintain backwards compatibility. See issue:
-      # https://github.com/messagebird/ruby-rest-api/issues/17
       raise ServerException, 'Unknown response from server' unless VALID_RESPONSE_CODES.include? code
     end
 

--- a/lib/messagebird/http_client.rb
+++ b/lib/messagebird/http_client.rb
@@ -79,7 +79,7 @@ module MessageBird
       # InvalidPhoneNumberException does not make a lot of sense here, but it's
       # needed to maintain backwards compatibility. See issue:
       # https://github.com/messagebird/ruby-rest-api/issues/17
-      raise InvalidPhoneNumberException, 'Unknown response from server' unless expected_codes.include? code
+      raise ServerException, 'Unknown response from server' unless VALID_RESPONSE_CODES.include? code
     end
 
     # Throw an exception if the response's content type is not JSON. This only

--- a/lib/messagebird/http_client.rb
+++ b/lib/messagebird/http_client.rb
@@ -11,6 +11,7 @@ module MessageBird
     attr_reader :access_key
 
     ENDPOINT = 'https://rest.messagebird.com/'
+    VALID_RESPONSE_CODES = [200, 201, 202, 204, 401, 404, 405, 422].freeze
 
     def initialize(access_key)
       @access_key = access_key
@@ -78,7 +79,6 @@ module MessageBird
       # InvalidPhoneNumberException does not make a lot of sense here, but it's
       # needed to maintain backwards compatibility. See issue:
       # https://github.com/messagebird/ruby-rest-api/issues/17
-      expected_codes = [200, 201, 202, 204, 401, 404, 405, 422]
       raise InvalidPhoneNumberException, 'Unknown response from server' unless expected_codes.include? code
     end
 

--- a/messagebird-rest.gemspec
+++ b/messagebird-rest.gemspec
@@ -23,11 +23,11 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
 
   if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.3.0")
-    gem "rspec", "~> 3.9.0", require: false
-    gem "rubocop", "~> 0.40.0", require: false
+    s.add_development_dependency "rspec", "~> 3.9.0"
+    s.add_development_dependency "rubocop", "~> 0.40.0"
   else
-    gem "rspec"
-    gem "rubocop", "~> 0.77.0", require: false
+    s.add_development_dependency "rspec"
+    s.add_development_dependency "rubocop", "~> 0.77.0"
   end
   s.add_development_dependency 'webmock', '~> 3.7.5'
 end

--- a/messagebird-rest.gemspec
+++ b/messagebird-rest.gemspec
@@ -20,4 +20,5 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
 
   s.add_development_dependency 'rspec', '~> 3.8'
+  s.add_development_dependency 'webmock', '~> 3.7.5'
 end

--- a/spec/error_spec.rb
+++ b/spec/error_spec.rb
@@ -12,4 +12,14 @@ describe 'Error' do
     expect{ client.message('some-id') }.to raise_error(MessageBird::ErrorException)
   end
 
+  context 'server responds with an invalid HTTP status code' do
+    it 'raises ServerException' do
+      stub_request(:any, /#{MessageBird::HttpClient::ENDPOINT}/)
+        .to_return(status: 500)
+
+      client = MessageBird::Client.new
+
+      expect { client.message('some-id') }.to raise_error(MessageBird::ServerException)
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,6 +9,7 @@
 require 'rspec'
 require 'rspec/mocks'
 require 'messagebird'
+require 'webmock/rspec'
 
 RSpec.configure do |config|
 


### PR DESCRIPTION
# Description

- Install [webmock](https://github.com/bblimke/webmock) gem in order to stub HTTP requests
- Create a Gemfile
- Add test case
- Replace `expected_codes` local variable by a `VALID_RESPONSE_CODES` constant
- Freeze `ENDPOINT` (https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/MutableConstant)
- Rename `MessageBird::InvalidPhoneNumberException` to `MessageBird::ServerException`
- Replace parent class by `StandardError`

Fixes https://github.com/messagebird/ruby-rest-api/issues/17