### PR TITLE
Switch from snake_case to camelCase for vmsg props.

### DIFF
--- a/examples/voice_message.rb
+++ b/examples/voice_message.rb
@@ -35,9 +35,9 @@ begin
   puts "  language            : #{vmsg.language}"
   puts "  voice               : #{vmsg.voice}"
   puts "  repeat              : #{vmsg.repeat}"
-  puts "  ifMachine           : #{vmsg.if_machine}"
-  puts "  scheduledDateTime   : #{vmsg.scheduled_date_time}"
-  puts "  createdDatetime     : #{vmsg.created_datetime}"
+  puts "  ifMachine           : #{vmsg.ifMachine}"
+  puts "  scheduledDateTime   : #{vmsg.scheduledDatetime}"
+  puts "  createdDatetime     : #{vmsg.createdDatetime}"
   puts "  recipients          : #{vmsg.recipients}"
   puts
 rescue MessageBird::ErrorException => e

--- a/examples/voice_message_create.rb
+++ b/examples/voice_message_create.rb
@@ -25,9 +25,9 @@ begin
   puts "  language            : #{vmsg.language}"
   puts "  voice               : #{vmsg.voice}"
   puts "  repeat              : #{vmsg.repeat}"
-  puts "  ifMachine           : #{vmsg.if_machine}"
-  puts "  scheduledDateTime   : #{vmsg.scheduled_date_time}"
-  puts "  createdDatetime     : #{vmsg.created_datetime}"
+  puts "  ifMachine           : #{vmsg.ifMachine}"
+  puts "  scheduledDateTime   : #{vmsg.scheduledDatetime}"
+  puts "  createdDatetime     : #{vmsg.createdDatetime}"
   puts "  recipients          : #{vmsg.recipients}"
   puts
 rescue MessageBird::ErrorException => e


### PR DESCRIPTION
After running the examples provided locally, I've encountered errors stating that snake_case props of `vmsg` do not exist, and that I should be using their camelCase counterparts.