### PR TITLE
improvement(conversation) allow call list without args to list all

### DIFF
--- a/lib/messagebird/client.rb
+++ b/lib/messagebird/client.rb
@@ -133,8 +133,17 @@ module MessageBird
       ))
     end
 
-    def conversation_list(limit = 0, offset = 0)
-      List.new(Conversation, conversation_request(:get, "conversations?limit=#{limit}&offset=#{offset}"))
+    def conversation_list(limit = -1, offset = -1)
+      query = '?'
+      if limit != -1
+        query += "limit=#{limit}&"
+      end
+
+      if offset != -1
+        query += "offset=#{offset}"
+      end
+
+      List.new(Conversation, conversation_request(:get, "conversations#{query}"))
     end
 
     def conversation(id)

--- a/spec/conversation_spec.rb
+++ b/spec/conversation_spec.rb
@@ -40,6 +40,21 @@ describe 'Conversation' do
     expect(list[0].id).to eq '00000000000000000000000000000000'
   end
 
+  it 'list without args'  do
+    conversation_client = double(MessageBird::ConversationClient)
+    client = MessageBird::Client.new('', nil, conversation_client)
+
+    expect(conversation_client)
+      .to receive(:request)
+      .with(:get, 'conversations?', {})
+      .and_return('{"offset":0,"limit":10,"count":2,"totalCount":2,"items":[{"id":"00000000000000000000000000000000"},{"id":"11111111111111111111111111111111"}]}')
+
+    list = client.conversation_list
+
+    expect(list.count).to eq 2
+    expect(list[0].id).to eq '00000000000000000000000000000000'
+  end
+
   it 'reads an existing' do
     conversation_client = double(MessageBird::ConversationClient)
     client = MessageBird::Client.new('', nil, conversation_client)


### PR DESCRIPTION
It's require to define limit and offset to list conversations. This pull request allow to list conversations without passing this args (list all).

It's have default values, when it is called with them it returns no results though.