### PR TITLE
improvement(conversation messages) allow call list using default values args to list all

### DIFF
--- a/lib/messagebird/client.rb
+++ b/lib/messagebird/client.rb
@@ -158,8 +158,17 @@ module MessageBird
       ConversationMessage.new(conversation_request(:post, "conversations/#{id}/messages", params))
     end
 
-    def conversation_messages_list(id, limit = 0, offset = 0)
-      List.new(ConversationMessage, conversation_request(:get, "conversations/#{id}/messages?limit=#{limit}&offset=#{offset}"))
+    def conversation_messages_list(id, limit = -1, offset = -1)
+      query = '?'
+      if limit != -1
+        query += "limit=#{limit}&"
+      end
+
+      if offset != -1
+        query += "offset=#{offset}"
+      end
+
+      List.new(ConversationMessage, conversation_request(:get, "conversations/#{id}/messages#{query}"))
     end
 
     def conversation_message(id)

--- a/spec/conversation_spec.rb
+++ b/spec/conversation_spec.rb
@@ -55,6 +55,40 @@ describe 'Conversation' do
     expect(list[0].id).to eq '00000000000000000000000000000000'
   end
 
+  it 'list messages' do
+    conversation_client = double(MessageBird::ConversationClient)
+    client = MessageBird::Client.new('', nil, conversation_client)
+
+    conversation_id = '5f3437fdb8444583aea093a047ac014b'
+
+    expect(conversation_client)
+      .to receive(:request)
+      .with(:get, "conversations/#{conversation_id}/messages?limit=2&offset=0", {})
+      .and_return('{"offset":0,"limit":10,"count":2,"totalCount":2,"items":[{"id":"00000000000000000000000000000000"},{"id":"11111111111111111111111111111111"}]}')
+
+    list = client.conversation_messages_list(conversation_id, 2, 0)
+
+    expect(list.count).to eq 2
+    expect(list[0].id).to eq '00000000000000000000000000000000'
+  end
+
+  it 'list messages without args' do
+    conversation_client = double(MessageBird::ConversationClient)
+    client = MessageBird::Client.new('', nil, conversation_client)
+
+    conversation_id = '5f3437fdb8444583aea093a047ac014b'
+
+    expect(conversation_client)
+      .to receive(:request)
+      .with(:get, "conversations/#{conversation_id}/messages?", {})
+      .and_return('{"offset":0,"limit":10,"count":2,"totalCount":2,"items":[{"id":"00000000000000000000000000000000"},{"id":"11111111111111111111111111111111"}]}')
+
+    list = client.conversation_messages_list(conversation_id)
+
+    expect(list.count).to eq 2
+    expect(list[0].id).to eq '00000000000000000000000000000000'
+  end
+
   it 'reads an existing' do
     conversation_client = double(MessageBird::ConversationClient)
     client = MessageBird::Client.new('', nil, conversation_client)


### PR DESCRIPTION
It's require to define limit and offset to list conversation messages. This pull request allow to list conversation messages without passing this args (list all).

It have default values, when it is called with them it returns no results though.

I also add tests to this function