### PR TITLE
Revert "Merge pull request #33 from mariuspot/whatsapp-sandbox"

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,17 +223,6 @@ pp client.number_search("NL", {:limit=>5})
  @type=MessageBird::Number>
 ````
 
-##### Conversations WhatsApp Sandbox
-
-To use the whatsapp sandbox you need to add `MessageBird::Client::ENABLE_CONVERSATIONS_WHATSAPP_SANDBOX` to the list of features you want enabled. Don't forget to replace `YOUR_ACCESS_KEY` with your actual access key.
-
-```ruby
-require 'messagebird'
-
-client = MessageBird::Client.new(YOUR_ACCESS_KEY)
-client.enable_feature(MessageBird::Client::CONVERSATIONS_WHATSAPP_SANDBOX_FEATURE)
-```
-
 Documentation
 -------------
 Complete documentation, instructions, and examples are available at:

--- a/lib/messagebird/client.rb
+++ b/lib/messagebird/client.rb
@@ -40,14 +40,8 @@ module MessageBird
     end
   end
 
-  class InvalidFeatureException < StandardError
-  end
-
   class Client
     attr_reader :access_key, :http_client, :conversation_client, :voice_client
-
-    CONVERSATIONS_WHATSAPP_SANDBOX_FEATURE = 'CONVERSATIONS_WHATSAPP_SANDBOX_FEATURE' # Enables the whatsapp sandbox
-    VALID_FEATURES = [CONVERSATIONS_WHATSAPP_SANDBOX_FEATURE].freeze # List of valid features for validation
 
     def initialize(access_key = nil, http_client = nil, conversation_client = nil, voice_client = nil)
       @access_key = access_key || ENV['MESSAGEBIRD_ACCESS_KEY']
@@ -55,22 +49,6 @@ module MessageBird
       @conversation_client = conversation_client || ConversationClient.new(@access_key)
       @number_client = http_client || NumberClient.new(@access_key)
       @voice_client = voice_client || VoiceClient.new(@access_key)
-    end
-
-    def enable_feature(feature)
-      if VALID_FEATURES.include? feature
-        @conversation_client.enable_feature(feature)
-      else
-        raise InvalidFeatureException
-      end
-    end
-
-    def disable_feature(feature)
-      if VALID_FEATURES.include? feature
-        @conversation_client.disable_feature(feature)
-      else
-        raise InvalidFeatureException
-      end
     end
 
     def conversation_request(method, path, params = {})

--- a/lib/messagebird/conversation_client.rb
+++ b/lib/messagebird/conversation_client.rb
@@ -7,34 +7,16 @@ require 'messagebird/http_client'
 
 module MessageBird
   class ConversationClient < HttpClient
-    attr_reader :endpoint
-
-    BASE_ENDPOINT = 'https://conversations.messagebird.com/v1/'
-    WHATSAPP_SANDBOX_ENDPOINT = 'https://whatsapp-sandbox.messagebird.com/v1/'
-
-    def initialize(access_key)
-      super(access_key)
-      @endpoint = BASE_ENDPOINT
-    end
-
-    def enable_feature(feature)
-      # To access the WhatsApp sandbox the endpoint changes to a proxy that emulates the real API to allow for easier testing of WhatsApp channels.
-      if feature == Client::CONVERSATIONS_WHATSAPP_SANDBOX_FEATURE
-        @endpoint = WHATSAPP_SANDBOX_ENDPOINT
-      end
-    end
-
-    def disable_feature(feature)
-      # When the feature gets disabled the endpoint changes back to the live endpoint.
-      if feature == Client::CONVERSATIONS_WHATSAPP_SANDBOX_FEATURE
-        @endpoint = BASE_ENDPOINT
-      end
-    end
+    ENDPOINT  = 'https://conversations.messagebird.com/v1/'
 
     def prepare_request(request, params = {})
       request['Content-Type'] = 'application/json'
       request.body = params.to_json
       request
+    end
+
+    def endpoint() 
+      ENDPOINT
     end
   end
 end

--- a/spec/conversation_spec.rb
+++ b/spec/conversation_spec.rb
@@ -3,7 +3,7 @@
 describe 'Conversation' do
   it 'sends a message' do
     conversation_client = double(MessageBird::ConversationClient)
-    client = MessageBird::Client.new('', nil, conversation_client)
+    client = MessageBird::Client.new('', conversation_client)
 
     expect(conversation_client)
       .to receive(:request)
@@ -15,7 +15,7 @@ describe 'Conversation' do
 
   it 'starts a conversation' do
     conversation_client = double(MessageBird::ConversationClient)
-    client = MessageBird::Client.new('', nil, conversation_client)
+    client = MessageBird::Client.new('', conversation_client)
 
     expect(conversation_client)
       .to receive(:request)
@@ -27,9 +27,9 @@ describe 'Conversation' do
 
   it 'lists' do
     conversation_client = double(MessageBird::ConversationClient)
-    client = MessageBird::Client.new('', nil, conversation_client)
+    client = MessageBird::Client.new('', conversation_client)
 
-    expect(conversation_client)
+    expect(http_client)
       .to receive(:request)
       .with(:get, 'conversations?limit=2&offset=0', {})
       .and_return('{"offset":0,"limit":10,"count":2,"totalCount":2,"items":[{"id":"00000000000000000000000000000000"},{"id":"11111111111111111111111111111111"}]}')
@@ -90,10 +90,10 @@ describe 'Conversation' do
   end
 
   it 'reads an existing' do
-    conversation_client = double(MessageBird::ConversationClient)
-    client = MessageBird::Client.new('', nil, conversation_client)
+    http_client = double(MessageBird::ConversationClient)
+    client = MessageBird::Client.new('', http_client)
 
-    expect(conversation_client)
+    expect(http_client)
       .to receive(:request)
       .with(:get, 'conversations/conversation-id', {})
       .and_return('{"id": "conversation-id","href": "https://conversations.messagebird.com/v1/conversations/conversation-id"}')
@@ -104,10 +104,10 @@ describe 'Conversation' do
   end
 
   it 'updates a conversation' do
-    conversation_client = double(MessageBird::ConversationClient)
-    client = MessageBird::Client.new('', nil, conversation_client)
+    http_client = double(MessageBird::ConversationClient)
+    client = MessageBird::Client.new('', http_client)
 
-    expect(conversation_client)
+    expect(http_client)
       .to receive(:request)
       .with(:patch, 'conversations/conversation-id', status: MessageBird::Conversation::CONVERSATION_STATUS_ARCHIVED)
       .and_return('{"id":"conversation-id", "contactId": "contact-id"}')
@@ -118,10 +118,10 @@ describe 'Conversation' do
   end
 
   it 'replies to a conversation' do
-    conversation_client = double(MessageBird::ConversationClient)
-    client = MessageBird::Client.new('', nil, conversation_client)
+    http_client = double(MessageBird::ConversationClient)
+    client = MessageBird::Client.new('', http_client)
 
-    expect(conversation_client)
+    expect(http_client)
       .to receive(:request)
       .with(:post, 'conversations/conversation-id/messages', type: 'text', content: { text: 'Hi there' })
       .and_return({ id: 'message-id', channel_id: 'channel-id', conversationId: 'conversation-id' }.to_json)
@@ -134,10 +134,10 @@ describe 'Conversation' do
   end
 
   it 'reads messages in a conversation' do
-    conversation_client = double(MessageBird::ConversationClient)
-    client = MessageBird::Client.new('', nil, conversation_client)
+    http_client = double(MessageBird::ConversationClient)
+    client = MessageBird::Client.new('', http_client)
 
-    expect(conversation_client)
+    expect(http_client)
       .to receive(:request)
       .with(:get, 'conversations/conversation-id/messages?limit=2&offset=0', {})
       .and_return('{"offset":0,"limit":10,"count":2,"totalCount":2,"items":[{"id":"00000000000000000000000000000000"},{"id":"11111111111111111111111111111111"}]}')
@@ -149,10 +149,10 @@ describe 'Conversation' do
   end
 
   it 'reads a message' do
-    conversation_client = double(MessageBird::ConversationClient)
-    client = MessageBird::Client.new('', nil, conversation_client)
+    http_client = double(MessageBird::ConversationClient)
+    client = MessageBird::Client.new('', http_client)
 
-    expect(conversation_client)
+    expect(http_client)
       .to receive(:request)
       .with(:get, 'messages/message-id', {})
       .and_return('{"id":"00000000000000000000000000000000"}')
@@ -163,10 +163,10 @@ describe 'Conversation' do
   end
 
   it 'creates a webhook' do
-    conversation_client = double(MessageBird::ConversationClient)
-    client = MessageBird::Client.new('', nil, conversation_client)
+    http_client = double(MessageBird::ConversationClient)
+    client = MessageBird::Client.new('', http_client)
 
-    expect(conversation_client)
+    expect(http_client)
       .to receive(:request)
       .with(:post, 'webhooks', channel_id: 'channel-id', events: [MessageBird::Conversation::WEBHOOK_EVENT_MESSAGE_CREATED, MessageBird::Conversation::WEBHOOK_EVENT_MESSAGE_UPDATED], url: 'url')
       .and_return('{"id":"00000000000000000000000000000000", "events": ["message.created", "message.updated"]}')
@@ -178,10 +178,10 @@ describe 'Conversation' do
   end
 
   it 'reads a list of webhooks' do
-    conversation_client = double(MessageBird::ConversationClient)
-    client = MessageBird::Client.new('', nil, conversation_client)
+    http_client = double(MessageBird::ConversationClient)
+    client = MessageBird::Client.new('', http_client)
 
-    expect(conversation_client)
+    expect(http_client)
       .to receive(:request)
       .with(:get, 'webhooks?limit=10&offset=0', {})
       .and_return('{"offset":0,"limit":10,"count":2,"totalCount":2,"items":[{"id":"00000000000000000000000000000000"},{"id":"11111111111111111111111111111111"}]}')
@@ -193,10 +193,10 @@ describe 'Conversation' do
   end
 
   it 'reads a webhook' do
-    conversation_client = double(MessageBird::ConversationClient)
-    client = MessageBird::Client.new('', nil, conversation_client)
+    http_client = double(MessageBird::ConversationClient)
+    client = MessageBird::Client.new('', http_client)
 
-    expect(conversation_client)
+    expect(http_client)
       .to receive(:request)
       .with(:get, 'webhooks/webhook-id', {})
       .and_return('{"id":"00000000000000000000000000000000"}')
@@ -207,10 +207,10 @@ describe 'Conversation' do
   end
 
   it 'updates a webhook' do
-    conversation_client = double(MessageBird::ConversationClient)
-    client = MessageBird::Client.new('', nil, conversation_client)
+    http_client = double(MessageBird::ConversationClient)
+    client = MessageBird::Client.new('', http_client)
 
-    expect(conversation_client)
+    expect(http_client)
       .to receive(:request)
       .with(:patch, 'webhooks/webhook-id', events: [MessageBird::Conversation::WEBHOOK_EVENT_MESSAGE_CREATED], url: 'url')
       .and_return('{"id":"00000000000000000000000000000000", "events": ["message.created"]}')
@@ -222,38 +222,14 @@ describe 'Conversation' do
   end
 
   it 'deletes a webhook' do
-    conversation_client = double(MessageBird::ConversationClient)
-    client = MessageBird::Client.new('', nil, conversation_client)
+    http_client = double(MessageBird::ConversationClient)
+    client = MessageBird::Client.new('', http_client)
 
-    expect(conversation_client)
+    expect(http_client)
       .to receive(:request)
       .with(:delete, 'webhooks/webhook-id', {})
       .and_return('')
 
     client.conversation_webhook_delete('webhook-id')
-  end
-
-  it 'enable whatsapp sandbox' do
-    conversation_client = MessageBird::ConversationClient.new('')
-    client = MessageBird::Client.new('', nil, conversation_client)
-
-    expect(conversation_client.endpoint).to eq 'https://conversations.messagebird.com/v1/'
-
-    client.enable_feature(MessageBird::Client::CONVERSATIONS_WHATSAPP_SANDBOX_FEATURE)
-
-    expect(conversation_client.endpoint).to eq 'https://whatsapp-sandbox.messagebird.com/v1/'
-
-    client.disable_feature(MessageBird::Client::CONVERSATIONS_WHATSAPP_SANDBOX_FEATURE)
-
-    expect(conversation_client.endpoint).to eq 'https://conversations.messagebird.com/v1/'
-  end
-
-  it 'invalid feature' do
-    conversation_client = MessageBird::ConversationClient.new('')
-    client = MessageBird::Client.new('', nil, conversation_client)
-
-    expect do
-      client.enable_feature('INVALID')
-    end.to raise_error(MessageBird::InvalidFeatureException)
   end
 end


### PR DESCRIPTION
The WhatsApp Sandbox has been properly integrated into Conversations API, so it shouldn't be accessed directly.