### PR TITLE
redo https://github.com/messagebird/ruby-rest-api/pull/53 slowly

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,17 +223,6 @@ pp client.number_search("NL", {:limit=>5})
  @type=MessageBird::Number>
 ````
 
-##### Conversations WhatsApp Sandbox
-
-To use the whatsapp sandbox you need to add `MessageBird::Client::ENABLE_CONVERSATIONS_WHATSAPP_SANDBOX` to the list of features you want enabled. Don't forget to replace `YOUR_ACCESS_KEY` with your actual access key.
-
-```ruby
-require 'messagebird'
-
-client = MessageBird::Client.new(YOUR_ACCESS_KEY)
-client.enable_feature(MessageBird::Client::CONVERSATIONS_WHATSAPP_SANDBOX_FEATURE)
-```
-
 Documentation
 -------------
 Complete documentation, instructions, and examples are available at:

--- a/lib/messagebird/client.rb
+++ b/lib/messagebird/client.rb
@@ -46,31 +46,12 @@ module MessageBird
   class Client
     attr_reader :access_key, :http_client, :conversation_client, :voice_client
 
-    CONVERSATIONS_WHATSAPP_SANDBOX_FEATURE = 'CONVERSATIONS_WHATSAPP_SANDBOX_FEATURE' # Enables the whatsapp sandbox
-    VALID_FEATURES = [CONVERSATIONS_WHATSAPP_SANDBOX_FEATURE].freeze # List of valid features for validation
-
     def initialize(access_key = nil, http_client = nil, conversation_client = nil, voice_client = nil)
       @access_key = access_key || ENV['MESSAGEBIRD_ACCESS_KEY']
       @http_client = http_client || HttpClient.new(@access_key)
       @conversation_client = conversation_client || ConversationClient.new(@access_key)
       @number_client = http_client || NumberClient.new(@access_key)
       @voice_client = voice_client || VoiceClient.new(@access_key)
-    end
-
-    def enable_feature(feature)
-      if VALID_FEATURES.include? feature
-        @conversation_client.enable_feature(feature)
-      else
-        raise InvalidFeatureException
-      end
-    end
-
-    def disable_feature(feature)
-      if VALID_FEATURES.include? feature
-        @conversation_client.disable_feature(feature)
-      else
-        raise InvalidFeatureException
-      end
     end
 
     def conversation_request(method, path, params = {})

--- a/lib/messagebird/conversation_client.rb
+++ b/lib/messagebird/conversation_client.rb
@@ -7,34 +7,16 @@ require 'messagebird/http_client'
 
 module MessageBird
   class ConversationClient < HttpClient
-    attr_reader :endpoint
-
-    BASE_ENDPOINT = 'https://conversations.messagebird.com/v1/'
-    WHATSAPP_SANDBOX_ENDPOINT = 'https://whatsapp-sandbox.messagebird.com/v1/'
-
-    def initialize(access_key)
-      super(access_key)
-      @endpoint = BASE_ENDPOINT
-    end
-
-    def enable_feature(feature)
-      # To access the WhatsApp sandbox the endpoint changes to a proxy that emulates the real API to allow for easier testing of WhatsApp channels.
-      if feature == Client::CONVERSATIONS_WHATSAPP_SANDBOX_FEATURE
-        @endpoint = WHATSAPP_SANDBOX_ENDPOINT
-      end
-    end
-
-    def disable_feature(feature)
-      # When the feature gets disabled the endpoint changes back to the live endpoint.
-      if feature == Client::CONVERSATIONS_WHATSAPP_SANDBOX_FEATURE
-        @endpoint = BASE_ENDPOINT
-      end
-    end
+    ENDPOINT = 'https://conversations.messagebird.com/v1/'
 
     def prepare_request(request, params = {})
       request['Content-Type'] = 'application/json'
       request.body = params.to_json
       request
     end
+  end
+
+  def endpoint
+    ENDPOINT
   end
 end

--- a/spec/conversation_spec.rb
+++ b/spec/conversation_spec.rb
@@ -233,27 +233,4 @@ describe 'Conversation' do
     client.conversation_webhook_delete('webhook-id')
   end
 
-  it 'enable whatsapp sandbox' do
-    conversation_client = MessageBird::ConversationClient.new('')
-    client = MessageBird::Client.new('', nil, conversation_client)
-
-    expect(conversation_client.endpoint).to eq 'https://conversations.messagebird.com/v1/'
-
-    client.enable_feature(MessageBird::Client::CONVERSATIONS_WHATSAPP_SANDBOX_FEATURE)
-
-    expect(conversation_client.endpoint).to eq 'https://whatsapp-sandbox.messagebird.com/v1/'
-
-    client.disable_feature(MessageBird::Client::CONVERSATIONS_WHATSAPP_SANDBOX_FEATURE)
-
-    expect(conversation_client.endpoint).to eq 'https://conversations.messagebird.com/v1/'
-  end
-
-  it 'invalid feature' do
-    conversation_client = MessageBird::ConversationClient.new('')
-    client = MessageBird::Client.new('', nil, conversation_client)
-
-    expect do
-      client.enable_feature('INVALID')
-    end.to raise_error(MessageBird::InvalidFeatureException)
-  end
 end

--- a/spec/conversation_spec.rb
+++ b/spec/conversation_spec.rb
@@ -232,5 +232,4 @@ describe 'Conversation' do
 
     client.conversation_webhook_delete('webhook-id')
   end
-
 end


### PR DESCRIPTION
There was once a special config for whatsapp sandbox. No more. 
There was a PR to fix this (https://github.com/messagebird/ruby-rest-api/pull/53) but it got stale. 

I manually moved the code here minimising changes (not touching tests that are working).  

