### PR TITLE
Provide more descriptive error messages when raising exceptions

### DIFF
--- a/lib/messagebird/client.rb
+++ b/lib/messagebird/client.rb
@@ -37,7 +37,7 @@ module MessageBird
 
     def initialize(errors)
       @errors = errors
-      message = errors.map { |error| error.message }.join(", ")
+      message = errors.map(&:message).join(', ')
       super(message)
     end
   end

--- a/lib/messagebird/client.rb
+++ b/lib/messagebird/client.rb
@@ -37,6 +37,8 @@ module MessageBird
 
     def initialize(errors)
       @errors = errors
+      message = errors.map { |error| error.message }.join(", ")
+      super(message)
     end
   end
 

--- a/lib/messagebird/error.rb
+++ b/lib/messagebird/error.rb
@@ -5,5 +5,13 @@ require 'messagebird/base'
 module MessageBird
   class Error < MessageBird::Base
     attr_accessor :code, :description, :parameter
+
+    def message
+      if parameter
+        "#{description} (error code: #{code}, parameter: #{parameter})"
+      else
+        "#{description} (error code: #{code})"
+      end
+    end
   end
 end

--- a/spec/error_spec.rb
+++ b/spec/error_spec.rb
@@ -9,7 +9,7 @@ describe 'Error' do
       .to receive(:request)
       .and_return('{"errors":[{"code": 2,"description": "Request not allowed (incorrect access_key)","parameter": "access_key"}]}')
 
-    expect { client.message('some-id') }.to raise_error(MessageBird::ErrorException, "Request not allowed (incorrect access_key) (error code: 2, parameter: access_key)")
+    expect { client.message('some-id') }.to raise_error(MessageBird::ErrorException, 'Request not allowed (incorrect access_key) (error code: 2, parameter: access_key)')
   end
 
   context 'server responds with an invalid HTTP status code' do
@@ -19,7 +19,7 @@ describe 'Error' do
 
       client = MessageBird::Client.new
 
-      expect { client.message('some-id') }.to raise_error(MessageBird::ServerException, "Unknown response from server")
+      expect { client.message('some-id') }.to raise_error(MessageBird::ServerException, 'Unknown response from server')
     end
   end
 end

--- a/spec/error_spec.rb
+++ b/spec/error_spec.rb
@@ -9,7 +9,7 @@ describe 'Error' do
       .to receive(:request)
       .and_return('{"errors":[{"code": 2,"description": "Request not allowed (incorrect access_key)","parameter": "access_key"}]}')
 
-    expect { client.message('some-id') }.to raise_error(MessageBird::ErrorException)
+    expect { client.message('some-id') }.to raise_error(MessageBird::ErrorException, "Request not allowed (incorrect access_key) (error code: 2, parameter: access_key)")
   end
 
   context 'server responds with an invalid HTTP status code' do
@@ -19,7 +19,7 @@ describe 'Error' do
 
       client = MessageBird::Client.new
 
-      expect { client.message('some-id') }.to raise_error(MessageBird::ServerException)
+      expect { client.message('some-id') }.to raise_error(MessageBird::ServerException, "Unknown response from server")
     end
   end
 end


### PR DESCRIPTION
Before this change the MessageBird::ErrorException always return the
same message in a stacktrace "MessageBird::ErrorException". Now it's
more descriptive and includes the error descriptions received from the
JSON payload.

This makes it a bit easier to debug when things go wrong.