### PR TITLE
Fix conversations client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /Gemfile.lock
 .rbenv-gemsets
 .ruby-version
+.byebug_history

--- a/lib/messagebird/base.rb
+++ b/lib/messagebird/base.rb
@@ -7,6 +7,8 @@ module MessageBird
   class Base
     # takes each element from the given hash and apply it to ourselves through an assignment method
     def map_hash_elements_to_self(hash)
+      return if hash.nil?
+
       hash.each do |key, value|
         method_name = key.gsub(/([a-z\d])([A-Z])/, '\1_\2').downcase # convert came case to snake case
         method_name += '='

--- a/lib/messagebird/conversation_client.rb
+++ b/lib/messagebird/conversation_client.rb
@@ -14,9 +14,9 @@ module MessageBird
       request.body = params.to_json
       request
     end
-  end
 
-  def endpoint
-    ENDPOINT
+    def endpoint
+      ENDPOINT
+    end
   end
 end

--- a/spec/base_spec.rb
+++ b/spec/base_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+describe '#map_hash_elements_to_self' do
+  context 'hash is nil' do
+    it 'doesnt raise errors' do
+      expect { @contact = MessageBird::Contact.new(nil) }.not_to raise_error
+    end
+  end
+
+  context 'hash is a contact' do
+    before(:all) do
+      @contact = MessageBird::Contact.new(
+        'id' => '03dfc27855c3475b953d6200a1b7eaf7',
+        'msisdn' => '+31600000000',
+        'firstName' => 'John',
+        'lastName' => 'Doe'
+      )
+    end
+
+    it 'contains an id' do
+      expect(@contact.id).to be('03dfc27855c3475b953d6200a1b7eaf7')
+    end
+
+    it 'contains a msisdn' do
+      expect(@contact.msisdn).to be('+31600000000')
+    end
+
+    it 'contains a first name' do
+      expect(@contact.first_name).to be('John')
+    end
+
+    it 'contains a last name' do
+      expect(@contact.last_name).to be('Doe')
+    end
+  end
+end

--- a/spec/conversation_client_spec.rb
+++ b/spec/conversation_client_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+describe MessageBird::ConversationClient do
+  before(:all) do
+    @client = MessageBird::ConversationClient.new('secret-access-key')
+  end
+
+  context 'initialization' do
+    it 'uses Conversations API base URL' do
+      expect(@client.endpoint).to eq('https://conversations.messagebird.com/v1/')
+    end
+
+    it 'uses the provided access key' do
+      expect(@client.access_key).to eq('secret-access-key')
+    end
+  end
+
+  context 'performing a HTTP request' do
+    before(:each) do
+      stub_request(:get, 'https://conversations.messagebird.com/v1/conversations')
+        .with(
+          headers: {
+            'Accept' => 'application/json',
+            'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+            'Authorization' => "AccessKey #{@client.access_key}",
+            'User-Agent' => "MessageBird/ApiClient/#{MessageBird::Version::STRING} Ruby/#{RUBY_VERSION}"
+          }
+        )
+        .to_return(status: 200, body: File.new(File.join(File.dirname(__FILE__), './data/conversations/list.json')), headers: {})
+
+      @response = JSON.parse(@client.request(:get, 'conversations'), symbolize_names: true)
+    end
+
+    it 'contains an offset in the HTTP response body' do
+      expect(@response[:offset]).to be(0)
+    end
+
+    it 'contains a limit in the HTTP response body' do
+      expect(@response[:limit]).to be(20)
+    end
+
+    it 'contains a count in the HTTP response body' do
+      expect(@response[:count]).to be(2)
+    end
+
+    it 'contains a totalCount in the HTTP response body' do
+      expect(@response[:totalCount]).to be(2)
+    end
+
+    it 'contains two items' do
+      expect(@response[:items].length).to be(2)
+    end
+  end
+end

--- a/spec/data/conversations/list.json
+++ b/spec/data/conversations/list.json
@@ -1,0 +1,94 @@
+{
+    "offset": 0,
+    "limit": 20,
+    "count": 2,
+    "totalCount": 2,
+    "items": [
+        {
+            "id": "fbbdde79129f45e3a179458a91e2ead6",
+            "contactId": "03dfc27855c3475b953d6200a1b7eaf7",
+            "contact": {
+                "id": "03dfc27855c3475b953d6200a1b7eaf7",
+                "href": "https://rest.messagebird.com/contacts/03dfc27855c3475b953d6200a1b7eaf7",
+                "msisdn": 31612345678,
+                "firstName": "John",
+                "lastName": "Doe",
+                "customDetails": {
+                    "custom1": null,
+                    "custom2": null,
+                    "custom3": null,
+                    "custom4": null
+                },
+                "createdDatetime": "2018-08-01T09:45:52Z",
+                "updatedDatetime": "2018-08-28T12:37:35Z"
+            },
+            "channels": [
+                {
+                    "id": "619747f69cf940a98fb443140ce9aed2",
+                    "name": "My WhatsApp",
+                    "platformId": "whatsapp",
+                    "status": "active",
+                    "createdDatetime": "2018-08-28T11:56:57Z",
+                    "updatedDatetime": "2018-08-29T08:16:33Z"
+                }
+            ],
+            "status": "active",
+            "createdDatetime": "2018-08-29T08:52:54Z",
+            "updatedDatetime": "2018-08-29T08:52:54Z",
+            "lastReceivedDatetime": "2018-08-29T08:52:54Z",
+            "lastUsedChannelId": "619747f69cf940a98fb443140ce9aed2",
+            "lastUsedPlatformId": "whatsapp",
+            "messages": {
+                "totalCount": 10,
+                "href": "https://conversations.messagebird.com/v1/conversations/fbbdde79129f45e3a179458a91e2ead6/messages"
+            }
+        },
+        {
+            "id": "2e15efafec384e1c82e9842075e87beb",
+            "contactId": "a621095fa44947a28b441cfdf85cb802",
+            "contact": {
+                "id": "a621095fa44947a28b441cfdf85cb802",
+                "href": "https://rest.messagebird.com/1/contacts/a621095fa44947a28b441cfdf85cb802",
+                "msisdn": 316123456789,
+                "firstName": "Jen",
+                "lastName": "Smith",
+                "customDetails": {
+                    "custom1": null,
+                    "custom2": null,
+                    "custom3": null,
+                    "custom4": null
+                },
+                "createdDatetime": "2018-06-03T20:06:03Z",
+                "updatedDatetime": null
+            },
+            "channels": [
+                {
+                    "id": "853eeb5348e541a595da93b48c61a1ae",
+                    "name": "SMS",
+                    "platformId": "sms",
+                    "status": "active",
+                    "createdDatetime": "2018-08-28T11:56:57Z",
+                    "updatedDatetime": "2018-08-29T08:16:33Z"
+                },
+                {
+                    "id": "619747f69cf940a98fb443140ce9aed2",
+                    "name": "My WhatsApp",
+                    "platformId": "whatsapp",
+                    "status": "active",
+                    "createdDatetime": "2018-08-28T11:56:57Z",
+                    "updatedDatetime": "2018-08-29T08:16:33Z"
+                }
+            ],
+            "status": "active",
+            "createdDatetime": "2018-08-13T09:17:22Z",
+            "updatedDatetime": "2018-08-29T07:35:48Z",
+            "lastReceivedDatetime": "2018-08-29T07:35:48Z",
+            "lastUsedChannelId": "853eeb5348e541a595da93b48c61a1ae",
+            "lastUsedPlatformId": "sms",
+            "messages": {
+                "totalCount": 23,
+                "href": "https://conversations.messagebird.com/v1/conversations/2e15efafec384e1c82e9842075e87beb/messages"
+            }
+        }
+    ]
+}


### PR DESCRIPTION
All HTTP requests performed by the `MessageBird::ConversationClient` are failing because it's using the base URL `rest.messagebird.com`, when it should be `conversations.messagebird.com`.

This PR does:

* Fix the aforementioned bug in the `MessageBird::ConversationClient` by moving the method `endpoint` from the `MessageBird` module to inside the class `MessageBird::ConversationClient`.
* Add tests for `MessageBird::ConversationClient`
* Add tests for `MessageBird::Base.map_hash_elements_to_self`
* Add `.byebug_history` to `.gitignore`
* Fixes a bug in the function `MessageBird::Base.map_hash_elements_to_self(hash)` by checking if `hash` is `nil`