### PR TITLE
Add changelog file and tagging release

### DIFF
--- a/.github/workflows/gh-release.yml
+++ b/.github/workflows/gh-release.yml
@@ -1,0 +1,35 @@
+name: Github Release
+
+on:
+  push:
+    branches: [ master ]
+
+jobs:
+  create-release:
+    name: Create Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Setup git
+        run: |
+          git config user.email "developers@messagebird.com"
+          git config user.name "MessageBird CI"
+      - name: Prepare description
+        run: |
+          csplit -s CHANGELOG.md "/##/" {1}
+          cat xx01 > CHANGELOG.tmp
+      - name: Prepare tag
+        run: |
+          export TAG=$(head -1 CHANGELOG.tmp | cut -d' ' -f2)
+          echo "TAG=$TAG" >> $GITHUB_ENV
+      - name: Create Release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ env.TAG }}
+          release_name: ${{ env.TAG }}
+          body_path: CHANGELOG.tmp
+          draft: false
+          prerelease: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,12 +50,21 @@ jobs:
           git config user.name "MessageBird CI"
           git fetch
           git checkout ${{ github.event.pull_request.head.ref }}
+      - name: Prepare CHANGELOG
+        run: |
+          echo "${{ github.event.pull_request.body }}" | csplit -s - "/##/"
+          echo "# Changelog
+          ## ${{ env.VERSION }}
+          " >> CHANGELOG.tmp
+          grep "^*" xx01 >> CHANGELOG.tmp
+          grep -v "^# " CHANGELOG.md >> CHANGELOG.tmp
+          cp CHANGELOG.tmp CHANGELOG.md
       - name: Prepare version.rb
         run: |
           sed -i "s|STRING = '[^']*'|STRING = '${{ env.VERSION }}'|" lib/messagebird/version.rb
       - name: Commit changes
         run: |
-          git add lib/messagebird/version.rb
+          git add CHANGELOG.md lib/messagebird/version.rb
           git commit -m "Bump to version ${{ env.VERSION }}"
       - name: Push
         run: git push

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 3.1.0
+
+* [ADDED] Add release and publish GitHub actions


### PR DESCRIPTION
## Description

A release tag is missing for github actions release workflow. This PR adds it.

## CHANGELOG

* [ADDED] Add release tagging workflow.
