### PR TITLE
Fix argument matchers in specs

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -18,13 +18,13 @@ Metrics/AbcSize:
 Metrics/CyclomaticComplexity:
   Enabled: false
 Metrics/BlockLength:
-  Enabled: false    
+  Enabled: false
 Style/Documentation:
   Enabled: false
 Style/GuardClause:
   Enabled: false
 Style/ConditionalAssignment:
-  Enabled: false 
+  Enabled: false
 Style/IfUnlessModifier:
   Enabled: false
 Style/WordArray:
@@ -34,4 +34,6 @@ Layout/ClosingParenthesisIndentation:
 Style/PercentLiteralDelimiters:
   Enabled: false
 Style/SymbolArray:
-  Enabled: false    
+  Enabled: false
+Style/BracesAroundHashParameters:
+  Enabled: false

--- a/spec/call_flow_spec.rb
+++ b/spec/call_flow_spec.rb
@@ -42,7 +42,7 @@ describe 'CallFlow' do
     }
     expect(voice_client)
       .to receive(:request)
-      .with(:post, 'call-flows', title: title, steps: steps, default: default, record: record)
+      .with(:post, 'call-flows', { title: title, steps: steps, default: default, record: record })
       .and_return(mock_data.to_json)
 
     call_flow = client.call_flow_create(title, steps, default, record)

--- a/spec/call_spec.rb
+++ b/spec/call_spec.rb
@@ -38,7 +38,7 @@ describe 'Call' do
   it 'create a call' do
     expect(voice_client)
       .to receive(:request)
-      .with(:post, 'calls', source: source, destination: destination, callFlow: call_flow.to_json)
+      .with(:post, 'calls', { source: source, destination: destination, callFlow: call_flow.to_json })
       .and_return('{"data":[{"id":"' + call_id + '","status":"queued","source":"' + source + '","destination":"' + destination + '","createdAt":"2019-10-11T13:02:19Z","updatedAt":"2019-10-11T13:02:19Z","endedAt":null}],"_links":{"self":"/calls/' + call_id + '"},"pagination":{"total_count":0,"pageCount":0,"currentPage":0,"perPage":0}}')
     call = client.call_create(source, destination, call_flow)
     expect(call.id).to eq call_id
@@ -47,7 +47,7 @@ describe 'Call' do
   it 'create a call with webhook' do
     expect(voice_client)
       .to receive(:request)
-      .with(:post, 'calls', source: source, destination: destination, callFlow: call_flow.to_json, webhook: webhook.to_json)
+      .with(:post, 'calls', { source: source, destination: destination, callFlow: call_flow.to_json, webhook: webhook.to_json })
       .and_return('{"data":[{"id":"' + call_id + '","status":"queued","source":"' + source + '","destination":"' + destination + '","createdAt":"2019-10-11T13:02:19Z","updatedAt":"2019-10-11T13:02:19Z","endedAt":null, "webhook":' + webhook.to_json + '}],"_links":{"self":"/calls/' + call_id + '"},"pagination":{"total_count":0,"pageCount":0,"currentPage":0,"perPage":0}}')
     call = client.call_create(source, destination, call_flow, webhook)
     expect(call.id).to eq call_id

--- a/spec/contact_spec.rb
+++ b/spec/contact_spec.rb
@@ -7,7 +7,7 @@ describe 'Contact' do
 
     expect(http_client)
       .to receive(:request)
-      .with(:post, 'contacts', msisdn: '31612345678', first_name: 'Foo', last_name: 'Bar', custom1: 'First', custom4: 'Fourth')
+      .with(:post, 'contacts', { msisdn: '31612345678', first_name: 'Foo', last_name: 'Bar', custom1: 'First', custom4: 'Fourth' })
       .and_return('{}')
 
     client.contact_create(31_612_345_678, first_name: 'Foo', last_name: 'Bar', custom1: 'First', custom4: 'Fourth')
@@ -108,7 +108,7 @@ describe 'Contact' do
 
     expect(http_client)
       .to receive(:request)
-      .with(:patch, 'contacts/contact-id', msisdn: 31_687_654_321, custom3: 'Third')
+      .with(:patch, 'contacts/contact-id', { msisdn: 31_687_654_321, custom3: 'Third' })
       .and_return('')
 
     client.contact_update('contact-id', msisdn: 31_687_654_321, custom3: 'Third')

--- a/spec/conversation_spec.rb
+++ b/spec/conversation_spec.rb
@@ -7,7 +7,7 @@ describe 'Conversation' do
 
     expect(conversation_client)
       .to receive(:request)
-      .with(:post, 'send', from: 'MBTest', to: 31_612_345_678, type: 'text', content: { text: 'Hi there!' })
+      .with(:post, 'send', { from: 'MBTest', to: 31_612_345_678, type: 'text', content: { text: 'Hi there!' } })
       .and_return('{}')
 
     client.send_conversation_message('MBTest', 31_612_345_678, type: 'text', content: { text: 'Hi there!' })
@@ -19,7 +19,7 @@ describe 'Conversation' do
 
     expect(conversation_client)
       .to receive(:request)
-      .with(:post, 'conversations/start', channel_id: 'c0dae31e440145e094c4708b7d000000', to: 31_612_345_678, type: 'text', content: { text: 'Hi there!' })
+      .with(:post, 'conversations/start', { channel_id: 'c0dae31e440145e094c4708b7d000000', to: 31_612_345_678, type: 'text', content: { text: 'Hi there!' } })
       .and_return('{}')
 
     client.start_conversation(31_612_345_678, 'c0dae31e440145e094c4708b7d000000', type: 'text', content: { text: 'Hi there!' })
@@ -109,7 +109,7 @@ describe 'Conversation' do
 
     expect(conversation_client)
       .to receive(:request)
-      .with(:patch, 'conversations/conversation-id', status: MessageBird::Conversation::CONVERSATION_STATUS_ARCHIVED)
+      .with(:patch, 'conversations/conversation-id', { status: MessageBird::Conversation::CONVERSATION_STATUS_ARCHIVED })
       .and_return('{"id":"conversation-id", "contactId": "contact-id"}')
     conversation = client.conversation_update('conversation-id', MessageBird::Conversation::CONVERSATION_STATUS_ARCHIVED)
 
@@ -123,7 +123,7 @@ describe 'Conversation' do
 
     expect(conversation_client)
       .to receive(:request)
-      .with(:post, 'conversations/conversation-id/messages', type: 'text', content: { text: 'Hi there' })
+      .with(:post, 'conversations/conversation-id/messages', { type: 'text', content: { text: 'Hi there' } })
       .and_return({ id: 'message-id', channel_id: 'channel-id', conversationId: 'conversation-id' }.to_json)
 
     msg = client.conversation_reply('conversation-id', type: 'text', content: { text: 'Hi there' })
@@ -168,7 +168,7 @@ describe 'Conversation' do
 
     expect(conversation_client)
       .to receive(:request)
-      .with(:post, 'webhooks', channel_id: 'channel-id', events: [MessageBird::Conversation::WEBHOOK_EVENT_MESSAGE_CREATED, MessageBird::Conversation::WEBHOOK_EVENT_MESSAGE_UPDATED], url: 'url')
+      .with(:post, 'webhooks', { channel_id: 'channel-id', events: [MessageBird::Conversation::WEBHOOK_EVENT_MESSAGE_CREATED, MessageBird::Conversation::WEBHOOK_EVENT_MESSAGE_UPDATED], url: 'url' })
       .and_return('{"id":"00000000000000000000000000000000", "events": ["message.created", "message.updated"]}')
 
     webhook = client.conversation_webhook_create('channel-id', 'url', [MessageBird::Conversation::WEBHOOK_EVENT_MESSAGE_CREATED, MessageBird::Conversation::WEBHOOK_EVENT_MESSAGE_UPDATED])
@@ -212,7 +212,7 @@ describe 'Conversation' do
 
     expect(conversation_client)
       .to receive(:request)
-      .with(:patch, 'webhooks/webhook-id', events: [MessageBird::Conversation::WEBHOOK_EVENT_MESSAGE_CREATED], url: 'url')
+      .with(:patch, 'webhooks/webhook-id', { events: [MessageBird::Conversation::WEBHOOK_EVENT_MESSAGE_CREATED], url: 'url' })
       .and_return('{"id":"00000000000000000000000000000000", "events": ["message.created"]}')
 
     webhook = client.conversation_webhook_update('webhook-id', events: [MessageBird::Conversation::WEBHOOK_EVENT_MESSAGE_CREATED], url: 'url')

--- a/spec/group_spec.rb
+++ b/spec/group_spec.rb
@@ -7,7 +7,7 @@ describe 'Group' do
 
     expect(http_client)
       .to receive(:request)
-      .with(:post, 'groups', name: 'friends')
+      .with(:post, 'groups', { name: 'friends' })
       .and_return('{}')
 
     client.group_create('friends')
@@ -76,7 +76,7 @@ describe 'Group' do
 
     expect(http_client)
       .to receive(:request)
-      .with(:patch, 'groups/group-id', name: 'family')
+      .with(:patch, 'groups/group-id', { name: 'family' })
       .and_return('{}')
 
     client.group_update('group-id', 'family')

--- a/spec/hlr_spec.rb
+++ b/spec/hlr_spec.rb
@@ -21,7 +21,7 @@ describe 'HLR' do
 
     expect(http_client)
       .to receive(:request)
-      .with(:post, 'hlr', msisdn: 31_612_345_678, reference: 'MyReference')
+      .with(:post, 'hlr', { msisdn: 31_612_345_678, reference: 'MyReference' })
       .and_return('{}')
 
     client.hlr_create(31_612_345_678, 'MyReference')

--- a/spec/lookup_spec.rb
+++ b/spec/lookup_spec.rb
@@ -22,7 +22,7 @@ describe 'Lookup' do
 
     expect(http_client)
       .to receive(:request)
-      .with(:get, 'lookup/0612345678', country_code: 'NL')
+      .with(:get, 'lookup/0612345678', { country_code: 'NL' })
       .and_return('{"href": "https://rest.messagebird.com/lookup/31612345678","countryCode": "NL","countryPrefix": 31,"phoneNumber": 31612345678,"type": "mobile","formats": {"e164": "+31612345678","international": "+31 6 12345678","national": "06 12345678","rfc3966": "tel:+31-6-12345678"},"hlr": {"id": "hlr-id","network": 20416,"reference": "reference2000","status": "active","createdDatetime": "2015-12-15T08:19:24+00:00","statusDatetime": "2015-12-15T08:19:25+00:00"}}')
 
     lookup = client.lookup('0612345678', country_code: 'NL')
@@ -53,7 +53,7 @@ describe 'Lookup HLR' do
 
     expect(http_client)
       .to receive(:request)
-      .with(:post, 'lookup/31612345678/hlr', reference: 'MyReference')
+      .with(:post, 'lookup/31612345678/hlr', { reference: 'MyReference' })
       .and_return('{}')
 
     client.lookup_hlr_create(31_612_345_678, reference: 'MyReference')

--- a/spec/message_spec.rb
+++ b/spec/message_spec.rb
@@ -21,7 +21,7 @@ describe 'Message' do
 
     expect(http_client)
       .to receive(:request)
-      .with(:post, 'messages', originator: 'MBTest', recipients: 31_612_345_678, body: 'Hello world', reference: 'Foo')
+      .with(:post, 'messages', { originator: 'MBTest', recipients: 31_612_345_678, body: 'Hello world', reference: 'Foo' })
       .and_return('{}')
 
     client.message_create('MBTest', 31_612_345_678, 'Hello world', reference: 'Foo')

--- a/spec/number_spec.rb
+++ b/spec/number_spec.rb
@@ -7,7 +7,7 @@ describe 'Numbers API' do
 
     expect(http_client)
       .to receive(:request)
-      .with(:get, 'available-phone-numbers/NL?limit=5', limit: 5)
+      .with(:get, 'available-phone-numbers/NL?limit=5', { limit: 5 })
       .and_return('{"items": [{"number": "3197010260188","country": "NL","region": "","locality": "","features": ["sms","voice"],"type": "mobile"},{"number": "3197010260188","country": "NL","region": "","locality": "","features": ["sms","voice"],"type": "mobile"}],"limit": 5,"count": 2}')
 
     numbers = client.number_search('NL', limit: 5)
@@ -24,7 +24,7 @@ describe 'Numbers API' do
 
     expect(http_client)
       .to receive(:request)
-      .with(:post, 'phone-numbers', number: '31971234567', countryCode: 'NL', billingIntervalMonths: 1)
+      .with(:post, 'phone-numbers', { number: '31971234567', countryCode: 'NL', billingIntervalMonths: 1 })
       .and_return('{"number": "31971234567","country": "NL","region": "Haarlem","locality": "Haarlem","features": ["sms","voice"],"tags": [],"type": "landline_or_mobile","status": "active","createdAt": "2019-04-25T14:04:04Z","renewalAt": "2019-05-25T00:00:00Z"}')
 
     number = client.number_purchase('31971234567', 'NL', 1)
@@ -47,7 +47,7 @@ describe 'Numbers API' do
 
     expect(http_client)
       .to receive(:request)
-      .with(:get, 'phone-numbers?type=mobile&features=sms&features=voice', type: 'mobile', features: ['sms', 'voice'])
+      .with(:get, 'phone-numbers?type=mobile&features=sms&features=voice', { type: 'mobile', features: ['sms', 'voice'] })
       .and_return('{"offset": 0,"limit": 20,"count": 1,"totalCount": 1,"items": [{"number": "31612345670","country": "NL","region": "Texel","locality": "Texel","features": ["sms","voice"],"tags": [],"type": "mobile","status": "active"}]}')
 
     numbers = client.number_fetch_all(type: 'mobile', features: ['sms', 'voice'])
@@ -90,7 +90,7 @@ describe 'Numbers API' do
 
     expect(http_client)
       .to receive(:request)
-      .with(:patch, 'phone-numbers/31612345670', tags: ['tag1'])
+      .with(:patch, 'phone-numbers/31612345670', { tags: ['tag1'] })
       .and_return('{"number": "31612345670","country": "NL","region": "Texel","locality": "Texel","features": ["sms","voice"],"tags": ["tag1"],"type": "mobile","status": "active"}')
 
     number = client.number_update('31612345670', ['tag1'])

--- a/spec/verify_spec.rb
+++ b/spec/verify_spec.rb
@@ -30,7 +30,7 @@ describe 'Verify' do
   it 'creates a verify and sends token' do
     expect(@http_client)
       .to receive(:request)
-      .with(:post, 'verify', recipient: 31_612_345_678, originator: 'MessageBird')
+      .with(:post, 'verify', { recipient: 31_612_345_678, originator: 'MessageBird' })
       .and_return('{}')
 
     @client.verify_create(31_612_345_678, originator: 'MessageBird')
@@ -39,7 +39,7 @@ describe 'Verify' do
   it 'creates a verify and sends token via email' do
     expect(@http_client)
       .to receive(:request)
-      .with(:post, 'verify', type: 'email', recipient: 'verify@example.com', subject: 'Your verification code', originator: 'MessageBird')
+      .with(:post, 'verify', { type: 'email', recipient: 'verify@example.com', subject: 'Your verification code', originator: 'MessageBird' })
       .and_return('{}')
 
     @client.verify_create('verify@example.com', originator: 'MessageBird', type: 'email', subject: 'Your verification code')

--- a/spec/voice_spec.rb
+++ b/spec/voice_spec.rb
@@ -7,7 +7,7 @@ describe 'Voice' do
 
     expect(voice_client)
       .to receive(:request)
-      .with(:post, 'webhooks', url: 'https://test.com', token: 'sometoken')
+      .with(:post, 'webhooks', { url: 'https://test.com', token: 'sometoken' })
       .and_return('{"data":[{"id":"00000000000000000000000000000000", "url": "https://test.com", "token": "sometoken"}]}')
 
     webhook = client.voice_webhook_create('https://test.com', token: 'sometoken')
@@ -53,7 +53,7 @@ describe 'Voice' do
 
     expect(voice_client)
       .to receive(:request)
-      .with(:put, 'webhooks/webhook-id', url: 'https://test.com', token: 'sometoken')
+      .with(:put, 'webhooks/webhook-id', { url: 'https://test.com', token: 'sometoken' })
       .and_return('{"data":[{"id":"00000000000000000000000000000000", "url": "https://test.com", "token": "sometoken"}]}')
 
     webhook = client.voice_webhook_update('webhook-id', url: 'https://test.com', token: 'sometoken')

--- a/spec/voicemessage_spec.rb
+++ b/spec/voicemessage_spec.rb
@@ -21,7 +21,7 @@ describe 'Voice message' do
 
     expect(http_client)
       .to receive(:request)
-      .with(:post, 'voicemessages', recipients: 31_612_345_678, body: 'Body', repeat: 3)
+      .with(:post, 'voicemessages', { recipients: 31_612_345_678, body: 'Body', repeat: 3 })
       .and_return('{}')
 
     client.voice_message_create(31_612_345_678, 'Body', repeat: 3)
@@ -33,7 +33,7 @@ describe 'Voice message' do
 
     expect(http_client)
       .to receive(:request)
-      .with(:post, 'voicemessages', recipients: '31612345678,31687654321', body: 'Body', repeat: 3)
+      .with(:post, 'voicemessages', { recipients: '31612345678,31687654321', body: 'Body', repeat: 3 })
       .and_return('{}')
 
     client.voice_message_create([31_612_345_678, 31_687_654_321], 'Body', repeat: 3)


### PR DESCRIPTION
Use hashes in argument matchers in specs instead of keywords. This matches how the function is actually called and should clear up some issues on Ci.