### PR TITLE
Deprecate CallFlow Title usage

### DIFF
--- a/lib/messagebird/client.rb
+++ b/lib/messagebird/client.rb
@@ -460,13 +460,13 @@ module MessageBird
       number_request(:delete, "phone-numbers/#{number}")
     end
 
-    def call_flow_create(title, steps, default, record, params = {})
+    def call_flow_create(steps, default, record, params = {})
       params = params.merge(
-        title: title,
         steps: steps,
         default: default,
         record: record
       )
+
       CallFlow.new(voice_request(:post, 'call-flows', params))
     end
 

--- a/spec/call_flow_spec.rb
+++ b/spec/call_flow_spec.rb
@@ -42,10 +42,10 @@ describe 'CallFlow' do
     }
     expect(voice_client)
       .to receive(:request)
-      .with(:post, 'call-flows', { title: title, steps: steps, default: default, record: record })
+      .with(:post, 'call-flows', { steps: steps, default: default, record: record })
       .and_return(mock_data.to_json)
 
-    call_flow = client.call_flow_create(title, steps, default, record)
+    call_flow = client.call_flow_create(steps, default, record)
     expect(call_flow.id).to eq call_flow_id
   end
 

--- a/spec/call_spec.rb
+++ b/spec/call_spec.rb
@@ -16,7 +16,6 @@ describe 'Call' do
   let(:webhook) { { url: 'https://example.com', token: 'token_to_sign_the_call_events_with' } }
   let(:call_flow) do
     {
-      title: 'Say message',
       steps: [
         {
           action: 'say',


### PR DESCRIPTION
This field is deprecated now although users still can send and receive it.