### PR TITLE
fix incorrect method name

### DIFF
--- a/lib/messagebird/recipient.rb
+++ b/lib/messagebird/recipient.rb
@@ -5,10 +5,10 @@ require 'messagebird/base'
 module MessageBird
   class Recipient < MessageBird::Base
     attr_accessor :recipient, :status
-    attr_reader :status_date_time
+    attr_reader :status_datetime
 
-    def status_date_time=(value)
-      @status_date_time = value_to_time(value)
+    def status_datetime=(value)
+      @status_datetime = value_to_time(value)
     end
   end
 end

--- a/spec/message_spec.rb
+++ b/spec/message_spec.rb
@@ -11,8 +11,10 @@ describe 'Message' do
       .and_return('{"body": "Hello World","createdDatetime": "2015-01-05T10:02:59+00:00","datacoding": "plain","direction": "mt","gateway": 239,"href": "https://rest.messagebird.com/messages/message-id","id": "message-id","mclass": 1,"originator": "TestName","recipients": {"items": [{"recipient": 31612345678,"status": "sent","statusDatetime": "2015-01-05T10:02:59+00:00"}],"totalCount": 1,"totalDeliveredCount": 0,"totalDeliveryFailedCount": 0,"totalSentCount": 1},"reference": null,"scheduled_date_time": null,"type": "sms","typeDetails": {},"validity": null}')
 
     message = client.message('message-id')
+    recipients = message.recipients['items']
 
     expect(message.id).to eq 'message-id'
+    expect(recipients.first.status_datetime.to_s).to eq '2015-01-05 10:02:59 +0000'
   end
 
   it 'creates' do


### PR DESCRIPTION
## Issue
Based on MessageBird's API documentation, `MessageBird::Recipient` object contains `statusDatetime`. But the library is currently throwing an error when attempting to retrieve `statusDatetime`

```
NoMethodError: undefined method `status_datetime' for #<MessageBird::Recipient:0x00000001125047a0 @recipient=6581825086, @status="delivered">
```

## Solution
After some digging, notice that this bug is due to incorrect method name. This PR renames the method so we can retrieve `statusDatetime` successfully

After this fix, the object looks like this:

```ruby
<MessageBird::Recipient:0x00000001172fd8a8 @recipient=6581825086, @status="delivered", @status_datetime=2022-09-20 06:17:51 +0000>
```

Also added a test case to ensure that the change works as expected