### PR TITLE
Relax JWT gem restriction

### DIFF
--- a/messagebird-rest.gemspec
+++ b/messagebird-rest.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.files        = Dir.glob('lib/**/*') + %w(LICENSE README.md)
   s.require_path = 'lib'
 
-  s.add_dependency "jwt",  "~> 2.3.0"
+  s.add_dependency "jwt",  "~> 2.3"
 
   s.add_development_dependency "rspec", "~> 3.11.0"
   s.add_development_dependency "rubocop", "~> 1.26.1"

--- a/spec/request_validator_spec.rb
+++ b/spec/request_validator_spec.rb
@@ -5,7 +5,7 @@ describe 'RequestValidator' do
     'invalid jwt: claim nbf is in the future' => 'Signature nbf has not been reached',
     'invalid jwt: claim exp is in the past' => 'Signature has expired',
     'invalid jwt: signing method none is invalid' => 'Expected a different algorithm',
-    'invalid jwt: signature is invalid' => 'Signature verification raised'
+    'invalid jwt: signature is invalid' => 'Signature verification failed'
   }.freeze
 
   path = File.join(File.dirname(__FILE__), './data/webhook_signature_test_data.json')


### PR DESCRIPTION
Allow MessageBird client to work with [ruby-jwt](https://github.com/jwt/ruby-jwt) 2.5.