### PR TITLE
Fix channel id typo in conversation methods

### DIFF
--- a/lib/messagebird/client.rb
+++ b/lib/messagebird/client.rb
@@ -114,7 +114,7 @@ module MessageBird
                          :post,
                          'conversations/start',
                          params.merge(to: to,
-                                      channel_id: channel_id)
+                                      ChannelId: channel_id)
       ))
     end
 
@@ -164,7 +164,7 @@ module MessageBird
       ConversationWebhook.new(conversation_request(
                                 :post,
                                 'webhooks',
-                                channel_id: channel_id,
+                                ChannelId: channel_id,
                                 url: url,
                                 events: events
       ))

--- a/spec/conversation_spec.rb
+++ b/spec/conversation_spec.rb
@@ -19,7 +19,7 @@ describe 'Conversation' do
 
     expect(conversation_client)
       .to receive(:request)
-      .with(:post, 'conversations/start', { channel_id: 'c0dae31e440145e094c4708b7d000000', to: 31_612_345_678, type: 'text', content: { text: 'Hi there!' } })
+      .with(:post, 'conversations/start', { ChannelId: 'c0dae31e440145e094c4708b7d000000', to: 31_612_345_678, type: 'text', content: { text: 'Hi there!' } })
       .and_return('{}')
 
     client.start_conversation(31_612_345_678, 'c0dae31e440145e094c4708b7d000000', type: 'text', content: { text: 'Hi there!' })
@@ -168,7 +168,7 @@ describe 'Conversation' do
 
     expect(conversation_client)
       .to receive(:request)
-      .with(:post, 'webhooks', { channel_id: 'channel-id', events: [MessageBird::Conversation::WEBHOOK_EVENT_MESSAGE_CREATED, MessageBird::Conversation::WEBHOOK_EVENT_MESSAGE_UPDATED], url: 'url' })
+      .with(:post, 'webhooks', { ChannelId: 'channel-id', events: [MessageBird::Conversation::WEBHOOK_EVENT_MESSAGE_CREATED, MessageBird::Conversation::WEBHOOK_EVENT_MESSAGE_UPDATED], url: 'url' })
       .and_return('{"id":"00000000000000000000000000000000", "events": ["message.created", "message.updated"]}')
 
     webhook = client.conversation_webhook_create('channel-id', 'url', [MessageBird::Conversation::WEBHOOK_EVENT_MESSAGE_CREATED, MessageBird::Conversation::WEBHOOK_EVENT_MESSAGE_UPDATED])


### PR DESCRIPTION
**TL.DR.**
This PR fixes this [issue](https://github.com/messagebird/ruby-rest-api/issues/84)

## Issue
Based on [MessageBird's Conversations API documentation](https://developers.messagebird.com/api/conversations#start-conversation), the `start_conversation` method should use a parameter named `ChannelId`, but at the `client.rb` file, it's being passed a `channel_id` param that generates a MessageBird::ServerException when trying to use the start_conversation method

## Solution
As mentioned in the referenced issue, the solution was just to change and fix the typo at the channel_id parameter: `channel_id` -> `ChannelId`, exactly the same as in the documentation.

Also fixed the tests to ensure that the change works as expected